### PR TITLE
Pin ekctl container to cwlf/eksctl:latest

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,5 +1,5 @@
 steps:
-- name: 'abdennour/eksctl:0.16.0-aws-1.18.39-kubectl-v1.18.1'
+- name: 'cwlf/eksctl:latest'
   entrypoint: 'bash'
   args: ['run.sh']
   secretEnv: ['AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY']


### PR DESCRIPTION
This is a temporary measure to ensure the initial managed nodegroup deployment is successful due to the new default IP mapping settings for public subnets required as a result of [recent behavior changes](https://aws.amazon.com/blogs/containers/upcoming-changes-to-ip-assignment-for-eks-managed-node-groups/) by AWS on April 22nd. 
eksctl support for this behavior was added in weaveworks/eksctl#2002 and pinned in 0.17.0
@abdennour is yet to update their supported eksctl container past 0.16.0, so this change should be temporary until this support catches up to the later releases of eksctl.